### PR TITLE
fix «SyntaxError: Block-scoped declarations (let, const, function, cl…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const allowedPolicies = [
 	'base-uri',
 	'block-all-mixed-content',


### PR DESCRIPTION
…ass) not yet supported outside strict mode» for Node v4.5.0 (and presumably v5)