### PR TITLE
Fix 'report-uri' param to be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare module 'csp-header' {
     policies?: csp.Policies;
     extend?: csp.Policies;
     presets?: Array<csp.Policies | string> | Dictionary<csp.Policies | string>;
-    'report-uri': string;
+    'report-uri'?: string;
   }
 
   function csp(params: Params): string;


### PR DESCRIPTION
Sorry, I had missed to add the optional indicator for 'report-uri'..