### PR TITLE
feat: adds support for prefetch-src

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare module 'csp-header' {
       'manifest-src'?: string[];
       'media-src'?: string[];
       'object-src'?: string[];
+      'prefetch-src'?: string[];
       'plugin-types'?: string[];
       'referrer'?: [ string ];
       'reflected-xss'?: boolean | string[];

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const allowedPolicies = [
 	'manifest-src',
 	'media-src',
 	'object-src',
+	'prefetch-src',
 	'plugin-types',
 	'referrer',
 	'reflected-xss',


### PR DESCRIPTION
:wave: Thanks for this library. It would be great if we could add the `preset-src` directive to the supported policies. Currently I have to use the `default-src`.

https://w3c.github.io/webappsec-csp/#directive-prefetch-src

Example of error reported during local testing.

```
Refused to prefetch content from 'http://localhost:8080/prefetch-url' because it violates the following Content Security Policy directive: "default-src 'none'". Note that 'prefetch-src' was not explicitly set, so 'default-src' is used as a fallback.
```
Please let me know if there's any further information I can provide here.