### PR TITLE
Fix extending policies with empty arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ function extendPolicies(original, extension) {
 
 		if (origPolicy === undefined) {
 			extended[policyName] = extPolicy;
-		} else if (Array.isArray(extPolicy) && extPolicy.length > 0 && Array.isArray(origPolicy)) {
+		} else if (Array.isArray(extPolicy) && Array.isArray(origPolicy)) {
 			extPolicy.forEach(rule => {
 				if (typeof rule === 'string' && origPolicy.indexOf(rule) === -1) {
 					extended[policyName].push(rule);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,6 +87,19 @@ test('Presets | resolve', t => {
 	t.is(csp.resolvePreset('test'), 'csp-preset-test');
 });
 
+test('Presets | empty array', t => {
+	const actual = csp({
+		policies: {
+			'script-src': ['test.com']
+		},
+		presets: [{
+			'script-src': []
+		}]
+	});
+
+	t.is(actual, 'script-src test.com;');
+});
+
 test('Extend | new rule', t => {
 	const actual = csp({
 		policies: {
@@ -124,6 +137,19 @@ test('Extend | new policy', t => {
 	});
 
 	t.is(actual, 'script-src myhost.com; style-src newhost.com;');
+});
+
+test('Extend | empty array', t => {
+	const actual = csp({
+		policies: {
+			'script-src': ['test.com']
+		},
+		extend: {
+			'script-src': []
+		}
+	});
+
+	t.is(actual, 'script-src test.com;');
 });
 
 test('Nonce', t => {


### PR DESCRIPTION
In 1.3.0 we're trying to work with empty array like with object: https://github.com/frux/csp-header/blob/master/index.js#L141
That cause error like this:
```
Error: Cannot read property 'length' of undefined
Object.keys.map.policyName (index.js:37:61)
buildCSPString (index.js:36:40)
csp (index.js:94:9)
```